### PR TITLE
Fix yarn package name parsing

### DIFF
--- a/.github/scripts/Tests.ps1
+++ b/.github/scripts/Tests.ps1
@@ -1,0 +1,1 @@
+Invoke-Pester -Path (Join-Path $PSScriptRoot "..\..\tests") -Verbose

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,3 +23,6 @@ jobs:
       - name: Build module
         run: ./build.ps1
         shell: pwsh
+      - name: Run tests
+        run: ./.github/scripts/Tests.ps1
+        shell: pwsh

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Build Crescendo module
         run: ./build.ps1
         shell: pwsh
+      - name: Run tests
+        run: ./.github/scripts/Tests.ps1
+        shell: pwsh
       - name: Publish PowerShell Module
         run: ./.github/scripts/Deploy.ps1
         shell: pwsh

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 obj/*
 output/*
 yarn.crescendo/*
-sample/node_modules/*
+**/node_modules/*

--- a/build.ps1
+++ b/build.ps1
@@ -58,5 +58,3 @@ $ManifestInfo = @{
 }
 
 Update-ModuleManifest -Path (Join-Path $Output "yarn.crescendo.psd1") @ManifestInfo -Verbose
-
-# Invoke-Pester -Path "$PSScriptRoot\tests"

--- a/src/Helpers/Find-PackageNameWithoutVersion.ps1
+++ b/src/Helpers/Find-PackageNameWithoutVersion.ps1
@@ -1,0 +1,8 @@
+
+function Find-PackageNameWithoutVersion($name) {
+    $idx = $name.LastIndexOf('@')
+    if ($idx -gt 0) {
+        $name = $name.Substring(0, $idx)
+    }
+    $name
+}

--- a/src/Helpers/Get-Packages.ps1
+++ b/src/Helpers/Get-Packages.ps1
@@ -4,6 +4,8 @@ param ( $CommandName,
     $CommandAst,
     $FakeBoundParameters )
 
+. (Join-Path $PSScriptRoot "Find-PackageNameWithoutVersion.ps1")
+
 if ([string]::IsNullOrEmpty($WordToComplete)) {
     $json = & yarn list --json | ConvertFrom-Json
 }
@@ -11,7 +13,6 @@ else {
     $json = & yarn list --pattern $WordToComplete --json | ConvertFrom-Json
 }
 $names = $json.data.trees | ForEach-Object { 
-    $nameWithoutVersion = $_.name.Split('@')[0] 
-    $nameWithoutVersion
+    Find-PackageNameWithoutVersion $_.name
 }
 return $names 

--- a/tests/Helpers.Tests.ps1
+++ b/tests/Helpers.Tests.ps1
@@ -1,0 +1,38 @@
+#Import-Module "$PSScriptRoot\..\yarn-crescendo\yarn.crescendo.psd1" -Force
+BeforeAll {
+    . "$PSScriptRoot\..\src\Helpers\Find-PackageNameWithoutVersion.ps1"
+}
+
+Describe "Find-PackageNameWithoutVersion" {
+    It "should return same string with -" {
+        Find-PackageNameWithoutVersion "some-package" | Should -Be "some-package"
+    }
+
+    It "should return same string with ." {
+        Find-PackageNameWithoutVersion "example.com" | Should -Be "example.com"
+    }
+
+    It "should return same string with _" {
+        Find-PackageNameWithoutVersion "under_score" | Should -Be "under_score"
+    }
+
+    It "should return same string starting with numbers" {
+        Find-PackageNameWithoutVersion "123numeric" | Should -Be "123numeric"
+    }
+
+    It "should return same string starting @" {
+        Find-PackageNameWithoutVersion "@npm/thingy" | Should -Be "@npm/thingy"
+    }
+    
+    It "should strip number" {
+        Find-PackageNameWithoutVersion "thingy@1.2.3" | Should -Be "thingy"
+    }
+
+    It "should strip number with ^" {
+        Find-PackageNameWithoutVersion "thingy@^1.2.3" | Should -Be "thingy"
+    }
+
+    It "should strip number" {
+        Find-PackageNameWithoutVersion "@npm/thingy@1.2.3" | Should -Be "@npm/thingy"
+    }
+}


### PR DESCRIPTION
- Fix yarn package name parsing to account for beginning '@'
- Add tests to test package name parsing function
- Add tests to CI and Deploy workflows
